### PR TITLE
moved directory_blacklist to config

### DIFF
--- a/include/config.inc.php
+++ b/include/config.inc.php
@@ -345,6 +345,22 @@ $cfg['external_storage']            = '/share/Usb/';
 
 
 //  +------------------------------------------------------------------------+
+//  | Directory Blacklist (those dirnames will not be scanned)               |
+//  +------------------------------------------------------------------------+
+unset($cfg['directory_blacklist']);
+
+$cfg['directory_blacklist'][]       = 'lost+found';
+$cfg['directory_blacklist'][]       = 'Temporary Items';
+$cfg['directory_blacklist'][]       = 'Network Trash Folder';
+$cfg['directory_blacklist'][]       = 'System Volume Information';
+$cfg['directory_blacklist'][]       = 'RECYCLER';
+$cfg['directory_blacklist'][]       = '$RECYCLE.BIN';
+$cfg['directory_blacklist'][]       = '.@__thumb';
+
+
+
+
+//  +------------------------------------------------------------------------+
 //  | Media extensions                                                       |
 //  +------------------------------------------------------------------------+
 unset($cfg['media_extension']);

--- a/update.php
+++ b/update.php
@@ -1,10 +1,10 @@
 <?php
 //  +------------------------------------------------------------------------+
-//  | O!MPD, Copyright © 2015-2016 Artur Sierzant	                         |
+//  | O!MPD, Copyright Â© 2015-2016 Artur Sierzant	                         |
 //  | http://www.ompd.pl                                             		 |
 //  |                                                                        |
 //  |                                                                        |
-//  | netjukebox, Copyright © 2001-2012 Willem Bartels                       |
+//  | netjukebox, Copyright Â© 2001-2012 Willem Bartels                       |
 //  |                                                                        |
 //  | http://www.netjukebox.nl                                               |
 //  | http://forum.netjukebox.nl                                             |
@@ -40,13 +40,10 @@ require_once('include/library.inc.php');
 ignore_user_abort(true);
 
 //exit();
-
+$logFile = '';
 if ($cfg['debug']) {
 	$logFile = NJB_HOME_DIR . 'tmp/update_log.txt';
 	ini_set('log_errors', 'On');
-}
-else {
-	$logFile = '';
 }
 
 $cfg['menu'] = 'config';
@@ -432,7 +429,7 @@ function recursiveScan($dir) {
 	}
 	
 	foreach ($entries as $entry) {
-		if ($entry[0] != '.' && !in_array($entry, array('lost+found', 'Temporary Items', 'Network Trash Folder', 'System Volume Information', 'RECYCLER', '$RECYCLE.BIN','.@__thumb'))) {
+		if ($entry[0] != '.' && in_array($entry, $cfg['directory_blacklist']) === FALSE) {
 			if (is_dir($dir . $entry . '/'))
 				recursiveScan($dir . $entry . '/');
 			else {
@@ -500,8 +497,8 @@ function countDirectories($base_dir) {
 		$extension = substr(strrchr($file, '.'), 1);
 		$extension = strtolower($extension);
 		if (in_array($extension, $cfg['media_extension'])) $isMediaDir = 1;
-		if($file == '.' || $file == '..' || $file == '.@__thumb') continue;
 		$dir = $base_dir.DIRECTORY_SEPARATOR.$file;
+		if($file == '.' || $file == '..' || (is_dir($dir) === TRUE && in_array($file, $cfg['directory_blacklist']) === TRUE)) continue;
 		if(is_dir($dir)) {
 			$directories []= $dir;
 			if ($isMediaDir == 1) {


### PR DESCRIPTION
Thanks to this little feature i was able to narrow down freezes in import/update procedure.
it's possible to put single album directories on this blacklist or directories with several terrabytes in size.

excerpt of my `include/config.local.inc.php`

```php
// some filesystem-image problem
$cfg['directory_blacklist'][] = 'MATUTO____THE_DEVIL_AND_THE_DIAMOND___(USA2013)___(280k_VBR)';

// PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 61514097 bytes) in /path/to/ompd/getid3/getid3/getid3.php on line 1702
$cfg['directory_blacklist'][] = 'VA-BrandNewWayo-Vol_37-mixcloud';

// skip multi-terrabyte-directory for faster analysing importer errors
$cfg['directory_blacklist'][] = 'Mixes';
```