### PR TITLE
Handle empty delimiter arrays correctly.

### DIFF
--- a/include/library.inc.php
+++ b/include/library.inc.php
@@ -55,7 +55,9 @@ function draw_tile($size,$album,$multidisc = '') {
 //  +---------------------------------------------------------------------------+
 
 function multiexplode ($delimiters,$string) {
-   
+    if (empty($delimiters)) {
+        return array($string);
+    }
     $ready = str_ireplace($delimiters, $delimiters[0], $string);
     $launch = explode($delimiters[0], $ready);
     return  $launch;


### PR DESCRIPTION
If splitting of fields is disabled by setting the delimiters to an
empty array, multiexplode returned an incorrect result before. Now it
returns an array with just the original string.